### PR TITLE
Fix system architecture diagram alignment

### DIFF
--- a/website/styles/technical.css
+++ b/website/styles/technical.css
@@ -85,7 +85,11 @@
   z-index: 5;
   padding: 0.5rem;
   text-align: center;
+  transform: translate(-50%, -50%); /* Added for centering satellite nodes */
 }
+
+/* Ensure central node's specific transform is not overridden if it's different,
+   but in this case, the central node already has its own more specific transform. */
 
 .diagram-node:hover {
   transform: scale(1.1);


### PR DESCRIPTION
Added `transform: translate(-50%, -50%);` to the .diagram-node CSS rule in technical.css. This ensures that satellite nodes in the System Architecture diagram on technical.html are correctly centered based on their `top` and `left` percentage styles, aligning them symmetrically around the central node.